### PR TITLE
test(esdoc2-publish-html-plugin): use correct babel-register path

### DIFF
--- a/packages/esdoc2-publish-html-plugin/package.json
+++ b/packages/esdoc2-publish-html-plugin/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "rm -rf ./out/src && babel --out-dir out/src --ignore 'Builder/template' src && cp -a src/Builder/template out/src/Builder/",
-    "test": "rm -rf ./test/fixture/out && node ./test/init.js && mocha -t 10000 --require ./node_modules/babel-register --recursive ./test/src -R spec"
+    "test": "rm -rf ./test/fixture/out && node ./test/init.js && mocha -t 10000 --require @babel/register --recursive ./test/src -R spec"
   },
   "keywords": [
     "esdoc2",


### PR DESCRIPTION
the path was still using the relative path to an older package
